### PR TITLE
Add allow-downloads to the Sandbox directive

### DIFF
--- a/src/Directives/Sandbox.php
+++ b/src/Directives/Sandbox.php
@@ -27,4 +27,5 @@ class Sandbox extends Directive
     public const ALLOW_SAME_ORIGIN = 'allow-same-origin';
     public const ALLOW_SCRIPTS = 'allow-scripts';
     public const ALLOW_TOP_NAVIGATION = 'allow-top-navigation';
+    public const ALLOW_DOWNLOADS = 'allow-downloads';
 }


### PR DESCRIPTION
If a page is sandboxed and allow-downloads is not defined, Chrome will now block the download even though it only mentions this for <iframe> elements in its changelog:
https://developers.google.com/web/updates/2020/04/chrome-83-deps-rems. Adding "allow-downloads" to the header fixes this issue, so we should include a constant for it.